### PR TITLE
Debug `main` in `gleeunit_ffi.mjs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.6.1 - 2022-01-26
+
+- Fixed a bug where failed tests on the JavaScript target would crash the `main`
+  function.
+- Fixed a bug where tests on the JavaScript target could succeed regardless of
+  return value.
+
 ## v0.6.0 - 2022-01-09
 
 - Added support for OTP versions below 23.

--- a/src/gleeunit_ffi.mjs
+++ b/src/gleeunit_ffi.mjs
@@ -35,11 +35,11 @@ export async function main() {
     for (let fnName of Object.keys(module)) {
       if (!fnName.endsWith("_test")) continue;
       try {
-        module[fnName]();
+        await module[fnName]();
         process.stdout.write(`\u001b[32m.\u001b[0m`);
         passes++;
       } catch (error) {
-        let moduleName = "\ngleam/" + entry.name.slice(0, -3);
+        let moduleName = "\n" + js_path.slice(0, -4);
         process.stdout.write(`\n❌ ${moduleName}.${fnName}: ${error}\n`);
         failures++;
       }


### PR DESCRIPTION
Allows `should` module functions and `assert` errors (all errors, actually) to work properly.