### PR TITLE
line number now output when test fails

### DIFF
--- a/src/gleeunit_ffi.mjs
+++ b/src/gleeunit_ffi.mjs
@@ -40,9 +40,12 @@ export async function main() {
         passes++;
       } catch (error) {
         let moduleName = "\n" + js_path.slice(0, -4);
-        const lineNumberInfo = `\nThe test failed at line ${error.line}\n`;
-        process.stdout.write(lineNumberInfo);
-        process.stdout.write(`\n❌ ${moduleName}.${fnName}: ${error}\n`);
+        if(error.line){
+          process.stdout.write(`\n❌ ${moduleName}.${fnName}:${error.line}: ${error}\n`);
+        }
+        else {
+          process.stdout.write(`\n❌ ${moduleName}.${fnName}: ${error}\n`);
+        }
         failures++;
       }
     }

--- a/src/gleeunit_ffi.mjs
+++ b/src/gleeunit_ffi.mjs
@@ -40,6 +40,8 @@ export async function main() {
         passes++;
       } catch (error) {
         let moduleName = "\n" + js_path.slice(0, -4);
+        const lineNumberInfo = `\nThe test failed at line ${error.line}\n`;
+        process.stdout.write(lineNumberInfo);
         process.stdout.write(`\n❌ ${moduleName}.${fnName}: ${error}\n`);
         failures++;
       }

--- a/test/another_test_module.gleam
+++ b/test/another_test_module.gleam
@@ -3,5 +3,5 @@ pub fn example_div_test() {
 }
 
 pub fn example_mult_test() {
-  assert 4 = 2 * 2
+  assert 4 = 2 * 7
 }

--- a/test/another_test_module.gleam
+++ b/test/another_test_module.gleam
@@ -3,5 +3,5 @@ pub fn example_div_test() {
 }
 
 pub fn example_mult_test() {
-  assert 4 = 2 * 7
+  assert 4 = 2 * 2
 }


### PR DESCRIPTION
should resolve #4 

To test:

modify an existing gleeunit test like:
```gleam
pub fn example_mult_test() {
  assert 4 = 2 * 7
}
```

Then run `gleam test --target=javascript` in your terminal. 

Example terminal output when an error occurs: 

```bash
  Compiling gleam_stdlib
  Compiling gleeunit
   Compiled in 1.16s
    Running gleeunit_test.main
.F.......
Failures:

  1) another_test_module:example_mult_test/0
     Failure: #{function => <<"example_mult_test">>,gleam_error => assert,
                line => 6,message => <<"Assertion pattern match failed">>,
                module => <<"another_test_module">>,value => 14}
     Stacktrace:
       another_test_module.example_mult_test
     Output: 

Finished in 0.036 seconds
9 tests, 1 failures
```
