### PR TITLE
Decouple halt from test runner

### DIFF
--- a/src/gleeunit.gleam
+++ b/src/gleeunit.gleam
@@ -7,8 +7,8 @@
 /// If running on JavaScript tests will be run with a custom test runner.
 ///
 pub fn main() -> Nil {
-  do_run_tests()
-  |> do_halt()
+  run_tests()
+  |> halt()
 }
 
 pub fn run_tests() -> Result(Nil, Nil) {
@@ -16,14 +16,18 @@ pub fn run_tests() -> Result(Nil, Nil) {
 }
 
 pub fn halt(result: Result(Nil, Nil)) -> Nil {
-  do_halt(result)
+  let code = case result {
+    Ok(_) -> 0
+    Error(_) -> 1
+  }
+  do_halt(code)
 }
 
 if javascript {
   external fn do_run_tests() -> Result(Nil, Nil) =
     "./gleeunit_ffi.mjs" "run_tests"
 
-  external fn do_halt(result: Result(Nil, Nil)) -> Nil =
+  external fn do_halt(Int) -> Nil =
     "./gleeunit_ffi.mjs" "halt"
 }
 
@@ -46,15 +50,7 @@ if erlang {
     |> result.map(fn(_) { Nil })
   }
 
-  fn do_halt(result: Result(Nil, Nil)) -> Nil {
-    let code = case result {
-      Ok(_) -> 0
-      Error(_) -> 1
-    }
-    erl_halt(code)
-  }
-
-  external fn erl_halt(Int) -> Nil =
+  external fn do_halt(Int) -> Nil =
     "erlang" "halt"
 
   fn gleam_to_erlang_module_name(path: String) -> String {

--- a/src/gleeunit_ffi.mjs
+++ b/src/gleeunit_ffi.mjs
@@ -53,8 +53,8 @@ ${passes + failures} tests, ${failures} failures`);
   return failures ? new Error(undefined) : new Ok(undefined);
 }
 
-export async function halt(result) {
-  process.exit(result === new Ok(undefined) ? 0 : 1);
+export async function halt(code) {
+  process.exit(code);
 }
 
 export function crash(message) {

--- a/src/gleeunit_ffi.mjs
+++ b/src/gleeunit_ffi.mjs
@@ -1,5 +1,6 @@
 import { readdir, readFile } from "fs/promises";
 import { join as joinPath } from "path";
+import { Ok, Error } from "./gleam.mjs";
 
 async function* gleamFiles(directory) {
   let dirents = await readdir(directory, { withFileTypes: true });
@@ -22,7 +23,7 @@ async function readRootPackageName() {
   throw new Error("Could not determine package name from gleam.toml");
 }
 
-export async function main() {
+export async function run_tests() {
   let passes = 0;
   let failures = 0;
 
@@ -49,7 +50,11 @@ export async function main() {
 
   console.log(`
 ${passes + failures} tests, ${failures} failures`);
-  process.exit(failures ? 1 : 0);
+  return failures ? new Error(undefined) : new Ok(undefined);
+}
+
+export async function halt(result) {
+  process.exit(result === new Ok(undefined) ? 0 : 1);
 }
 
 export function crash(message) {


### PR DESCRIPTION
Adds do_run_tests() and do_halt(result), allowing a user run tests, execute a cleanup action, then halt the runtime with the appropriate exit code.