### PR TITLE
`should.be_ok` and `should.be_error` also unwrap the result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.8
+
+- `should.be_ok` and `should.be_error` now unwrap the result argument
+
 ## v0.7.2 - 2022-11-19
 
 - Update for Gleam v0.25.0.

--- a/src/gleeunit/should.gleam
+++ b/src/gleeunit/should.gleam
@@ -11,10 +11,10 @@ if erlang {
   pub external fn not_equal(a, a) -> Nil =
     "gleeunit_ffi" "should_not_equal"
 
-  pub external fn be_ok(Result(a, b)) -> Nil =
+  pub external fn be_ok(Result(a, b)) -> a =
     "gleeunit_ffi" "should_be_ok"
 
-  pub external fn be_error(Result(a, b)) -> Nil =
+  pub external fn be_error(Result(a, b)) -> b =
     "gleeunit_ffi" "should_be_error"
 }
 
@@ -55,14 +55,14 @@ if javascript {
 
   pub fn be_ok(a) {
     case a {
-      Ok(_) -> Nil
+      Ok(value) -> value
       _ -> crash(string.concat(["\n", stringify(a), "\nshould be ok"]))
     }
   }
 
   pub fn be_error(a) {
     case a {
-      Error(_) -> Nil
+      Error(error) -> error
       _ -> crash(string.concat(["\n", stringify(a), "\nshould be error"]))
     }
   }

--- a/src/gleeunit_ffi.erl
+++ b/src/gleeunit_ffi.erl
@@ -18,7 +18,7 @@ should_not_equal(Actual, Expected) ->
     nil.
 should_be_ok(A) -> 
     ?assertMatch({ok, _}, A),
-    nil.
+    element(2, A).
 should_be_error(A) -> 
     ?assertMatch({error, _}, A),
-    nil.
+    element(2, A).


### PR DESCRIPTION
Right now, if we want to test whether a result is `Ok` and also check the value, this is what we have to do:

```gleam
pub fn mock_test() {
  process()
  |> should.equal(Ok(correct_result))
}
```

which is fine, but imagine the following scenario:

```gleam
pub fn mock_test() {
  process()
  |> should.equal(Ok(2 * base_value * { 1 - ratio }))
}
```

With this change, I think we could make it a bit cleaner:

```gleam
pub fn mock_test() {
  process()
  |> should.be_ok
  |> should.equal(2 * base_value * { 1 - ratio })
}
```
The same with `should.be_error`.

There is also the fact that in my experience, people are just not using `should.be_ok` and `should.be_error` because they usually need to also check the inner value.