### PR TITLE
refactor main to create main_with and add coverage

### DIFF
--- a/src/gleeunit.gleam
+++ b/src/gleeunit.gleam
@@ -1,16 +1,16 @@
-/// Find and run all test functions for the current project using Erlang's EUnit
-/// test framework.
-///
-/// Any Erlang or Gleam function in the `test` directory with a name editing in
-/// `_test` is considered a test function and will be run.
-///
-/// If running on JavaScript tests will be run with a custom test runner.
-///
-pub fn main() -> Nil {
-  do_main()
-}
-
 if javascript {
+  /// Find and run all test functions for the current project using Erlang's EUnit
+  /// test framework.
+  ///
+  /// Any Erlang or Gleam function in the `test` directory with a name editing in
+  /// `_test` is considered a test function and will be run.
+  ///
+  /// If running on JavaScript tests will be run with a custom test runner.
+  ///
+  pub fn main() -> Nil {
+    do_main()
+  }
+
   external fn do_main() -> Nil =
     "./gleeunit_ffi.mjs" "main"
 }
@@ -19,10 +19,31 @@ if erlang {
   import gleam/list
   import gleam/result
   import gleam/string
+  import gleam/io
   import gleam/dynamic.{Dynamic}
 
-  fn do_main() -> Nil {
-    let options = [Verbose, NoTty, Report(#(GleeunitProgress, [Colored(True)]))]
+  pub fn main() -> Nil {
+    do_main([Colored(True)])
+  }
+
+  pub fn main_with(opts: List(GleeunitProgressOption)) -> Nil {
+    do_main(opts)
+  }
+
+  fn do_main(opts: List(GleeunitProgressOption)) -> Nil {
+    let options = [Verbose, NoTty, Report(#(GleeunitProgress, opts))]
+    let coverage = list.contains(opts, Coverage(True))
+
+    case coverage {
+      True -> {
+        do_cover_start()
+        find_files(matching: "**/*.{erl,gleam}", in: "src")
+        |> list.map(gleam_to_erlang_module_name)
+        |> list.map(dangerously_convert_string_to_atom(_, Utf8))
+        |> list.each(recompile_for_coverage)
+      }
+      False -> Nil
+    }
 
     let result =
       find_files(matching: "**/*.{erl,gleam}", in: "test")
@@ -31,6 +52,11 @@ if erlang {
       |> run_eunit(options)
       |> dynamic.result(dynamic.dynamic, dynamic.dynamic)
       |> result.unwrap(Error(dynamic.from(Nil)))
+
+    case coverage {
+      True -> do_cover_stop()
+      False -> Nil
+    }
 
     let code = case result {
       Ok(_) -> 0
@@ -49,6 +75,27 @@ if erlang {
     |> string.replace("/", "@")
   }
 
+  fn recompile_for_coverage(module) -> Atom {
+    case do_cover_recompile_module(module) {
+      Ok(_) -> {
+        module
+      }
+      Error(err) -> {
+        io.debug(#("cannot compile coverage", err))
+        module
+      }
+    }
+  }
+
+  external fn do_cover_start() -> Nil =
+    "gleeunit_ffi" "start_coverage"
+
+  external fn do_cover_stop() -> Nil =
+    "gleeunit_ffi" "stop_coverage"
+
+  external fn do_cover_recompile_module(module: Atom) -> Result(Nil, String) =
+    "gleeunit_ffi" "compile_coverage"
+
   external fn find_files(matching: String, in: String) -> List(String) =
     "gleeunit_ffi" "find_files"
 
@@ -65,8 +112,10 @@ if erlang {
     GleeunitProgress
   }
 
-  type GleeunitProgressOption {
+  pub type GleeunitProgressOption {
     Colored(Bool)
+    Profile(Bool)
+    Coverage(Bool)
   }
 
   type EunitOption {

--- a/src/gleeunit_binomial_heap.erl
+++ b/src/gleeunit_binomial_heap.erl
@@ -1,0 +1,95 @@
+-module(gleeunit_binomial_heap).
+
+-record(node,{
+    rank = 0    :: non_neg_integer(),
+    key         :: term(),
+    value       :: term(),
+    children = new() :: binomial_heap()
+  }).
+
+-export_type([binomial_heap/0, heap_node/0]).
+-type binomial_heap() :: [ heap_node() ].
+-type heap_node() :: #node{}.
+
+-export([new/0, insert/2, insert/3, merge/2, delete/1, to_list/1, take/2, size/1, link/2]).
+
+-spec new() -> binomial_heap().
+new() ->
+    [].
+
+% Inserts a new pair into the heap (or creates a new heap)
+-spec insert(term(), term()) -> binomial_heap().
+insert(Key, Value) ->
+    insert(Key, Value, []).
+
+-spec insert(term(), term(), binomial_heap()) -> binomial_heap().
+insert(Key, Value, Forest) ->
+    insTree(#node{key = Key, value = Value}, Forest).
+
+% Merges two heaps
+-spec merge(binomial_heap(), binomial_heap()) -> binomial_heap().
+merge(TS1, []) when is_list(TS1) -> TS1;
+merge([], TS2) when is_list(TS2) -> TS2;
+merge([#node{rank = R1} = T1 | TS1], [#node{rank = R2} | _] = F2) when R1 < R2 ->
+    [T1 | merge(TS1, F2)];
+merge([#node{rank = R1} | _] = F1, [#node{rank = R2} = T2 | TS2]) when R2 < R1 ->
+    [T2 | merge(F1, TS2)];
+merge([T1 | TS1], [T2 | TS2]) ->
+    insTree(link(T1, T2), merge(TS1, TS2)).
+
+% Deletes the top entry from the heap and returns it
+-spec delete(binomial_heap()) -> {{term(), term()}, binomial_heap()}.
+delete(TS) ->
+    {#node{key=Key,value=Value,children=TS1},TS2} = getMin(TS),
+    {{Key,Value},merge(lists:reverse(TS1),TS2)}.
+
+% Turns the heap into list in heap order
+-spec to_list(binomial_heap()) -> [{term(), term()}].
+to_list([]) -> [];
+to_list(List) when is_list(List) ->
+    to_list([],List).
+to_list(Acc, []) ->
+    lists:reverse(Acc);
+to_list(Acc,Forest) ->
+    {Next, Trees} = delete(Forest),
+    to_list([Next|Acc], Trees).
+
+% Take N elements from the top of the heap
+-spec take(non_neg_integer(), binomial_heap()) -> [{term(), term()}].
+take(N,Trees) when is_integer(N), is_list(Trees) ->
+    take(N,Trees,[]).
+take(0,_Trees,Acc) ->
+    lists:reverse(Acc);
+take(_N,[],Acc)->
+    lists:reverse(Acc);
+take(N,Trees,Acc) ->
+    {Top,T2} = delete(Trees),
+    take(N-1,T2,[Top|Acc]).
+
+% Get an estimate of the size based on the binomial property
+-spec size(binomial_heap()) -> non_neg_integer().
+size(Forest) ->
+    erlang:trunc(lists:sum([math:pow(2,R) || #node{rank=R} <- Forest])).
+
+%% Private API
+-spec link(heap_node(), heap_node()) -> heap_node().
+link(#node{rank=R,key=X1,children=C1}=T1,#node{key=X2,children=C2}=T2) ->
+    case X1 < X2 of
+        true ->
+            T1#node{rank=R+1,children=[T2|C1]};
+        _ ->
+            T2#node{rank=R+1,children=[T1|C2]}
+    end.
+
+insTree(Tree, []) ->
+    [Tree];
+insTree(#node{rank = R1} = T1, [#node{rank = R2} | _] = TS) when R1 < R2 -> [T1 | TS];
+insTree(T1, [T2 | Rest]) -> insTree(link(T1, T2), Rest).
+
+getMin([T]) -> {T, []};
+getMin([#node{key = K} = T | TS]) ->
+    {#node{key = K1} = T1, TS1} = getMin(TS),
+    case K < K1 of
+        true -> {T, TS};
+        _ -> {T1, [T | TS1]}
+    end.

--- a/src/gleeunit_ffi.erl
+++ b/src/gleeunit_ffi.erl
@@ -1,7 +1,8 @@
 -module(gleeunit_ffi).
 
 -export([find_files/2, should_equal/2, should_not_equal/2, should_be_ok/1,
-         should_be_error/1]).
+         should_be_error/1, start_coverage/0, compile_coverage/1,
+         stop_coverage/0]).
 
 -include_lib("eunit/include/eunit.hrl").
 
@@ -22,3 +23,58 @@ should_be_ok(A) ->
 should_be_error(A) -> 
     ?assertMatch({error, _}, A),
     element(2, A).
+
+start_coverage() ->
+    cover:start(),
+    nil.
+
+compile_coverage(Mod) ->
+    case cover:compile_beam(Mod) of
+        {ok, _} ->
+            {ok, nil};
+        {error, not_main_node} ->
+            {error, <<"not_main_node">>};
+        {error, _Mod} ->
+            {error, <<"invalid_module">>}
+    end.
+
+stop_coverage() ->
+    case cover:analyse() of
+        {result, Values, Errors} ->
+            NewValues =
+                [ {Mod, {Cov, NotCov}} || {{Mod,_F,_A}, {Cov, NotCov}} <- Values ],
+            NewErrors =
+                [ {Mod, {0, 0}} || {not_cover_compiled, Mod} <- Errors ],
+            MapValues =
+                lists:foldl(fun({Mod, {Cov, NotCov}}, Acc) ->
+                                MergeFun = fun({OldCov, OldNotCov}) ->
+                                            NewCov = OldCov + Cov,
+                                            NewNotCov = OldNotCov + NotCov,
+                                            {NewCov, NewNotCov}
+                                            end,
+                                maps:update_with(Mod, MergeFun, {Cov, NotCov}, Acc)
+                            end, #{}, NewValues ++ NewErrors),
+            Calc = fun(Cov, NotCov) -> Cov / (Cov + NotCov) * 100 end,
+            Get = fun(Key, List) -> proplists:get_value(Key, List) end,
+            ModInfo = fun(Mod) -> filename:basename(Get(source, Get(compile, Mod:module_info()))) end,
+            Return = [ {cover, ModInfo(Mod), Cov, NotCov, Calc(Cov, NotCov)} || {Mod, {Cov, NotCov}} <- maps:to_list(MapValues) ],
+            NSize = lists:max([string:len(Mod) || {cover, Mod, _, _, _} <- Return]),
+            Size = integer_to_list(NSize),
+            io:fwrite("\n\nTest coverage:\n\n"),
+            io:format("~-" ++ Size ++ "s ~7s (~s)\n", ["Module", "Perc%", "Covered/Total"]),
+            io:format([
+                lists:duplicate(NSize, "-"), " ",
+                lists:duplicate(7, "-"), " ",
+                lists:duplicate(15, "-"), "\n"
+            ]),
+            lists:foreach(fun(Cover) -> print_cover(Cover, Size) end, Return),
+            nil;
+
+        {error, not_main_node} ->
+            nil
+    end.
+
+print_cover({cover, Mod, Cov, NotCov, Percent}, Size) ->
+    Total = Cov + NotCov,
+    io:format("~-" ++ Size ++ "s ~6.2f% (~b/~b)~n", [Mod, Percent, Cov, Total]),
+    nil.

--- a/test/gleeunit_test.gleam
+++ b/test/gleeunit_test.gleam
@@ -1,7 +1,7 @@
-import gleeunit
+import gleeunit.{Colored, Coverage, Profile}
 
 pub fn main() {
-  gleeunit.main()
+  gleeunit.main_with([Colored(True), Profile(True), Coverage(True)])
 }
 
 pub fn some_test() {


### PR DESCRIPTION
The idea is to let us use `main_with` in this way:
```gleam
pub fn main() {
  gleeunit.main_with([Colored(True), Profile(True), Coverage(True)])
}
```
That's letting us to activate profile (which couldn't be activated previously, change the coloured if we want and add the new coverage option to generate:
```
Finished in 0.062 seconds
14 tests, 0 failures


Test coverage:

Module                       Perc% (Covered/Total)
-------------------------- ------- ---------------
gleeunit.erl                 0.00% (0/35)
gleeunit@should.erl          0.00% (0/9)
gleeunit_binomial_heap.erl  62.50% (20/32)
gleeunit_ffi.erl            16.28% (7/43)
gleeunit_progress.erl       34.78% (80/230)
```