### PR TITLE
feat: Add `Option` assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.1.0
+
+- Added `Option` assertions: `should.be_some` and `should.be_none`
+
 ## v1.0.2 - 2023-12-19
 
 - Added Gleam v0.33.0 version requirement.

--- a/src/gleeunit/should.gleam
+++ b/src/gleeunit/should.gleam
@@ -5,6 +5,7 @@
 //// documentation](https://rebar3.org/docs/testing/eunit/).
 
 import gleam/string
+import gleam/option.{type Option, None, Some}
 
 @external(erlang, "gleeunit_ffi", "should_equal")
 pub fn equal(a: t, b: t) -> Nil {
@@ -47,6 +48,20 @@ pub fn be_error(a: Result(a, e)) -> e {
   case a {
     Error(error) -> error
     _ -> panic as string.concat(["\n", string.inspect(a), "\nshould be error"])
+  }
+}
+
+pub fn be_some(a: Option(a)) -> a {
+  case a {
+    Some(value) -> value
+    _ -> panic as string.concat(["\n", string.inspect(a), "\nshould be some"])
+  }
+}
+
+pub fn be_none(a: Option(a)) -> Nil {
+  case a {
+    None -> Nil
+    _ -> panic as string.concat(["\n", string.inspect(a), "\nshould be none"])
   }
 }
 


### PR DESCRIPTION
This PR adds the assertions `be_some` and `be_none` for the `Option` type, which are analogous of the ones for the `Result` type.

@lpil I wanted to add some tests, but I didn't see any for the rest of the assertions, please advise which would be the best way to do this if necessary, or if there's anything else that I can do for this new assertions proposal 🙏 