### PR TITLE
chore: broken gh links, gleam 1.2 formatter, fix up changelog as good as possible

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ name: test
 on:
   push:
     branches:
-      - master
       - main
   pull_request:
 
@@ -15,7 +14,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "25.1"
-          gleam-version: "1.0.0"
+          gleam-version: "1.2.0"
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.beam
 *.ez
 build
+.tool-versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## v1.1.0
+## v1.1.3 - 2024-06-10
+
+- Fixed docs repo link by republishing to hex.pm.
+
+## v1.1.0 - 2024-03-30
 
 - Added `Option` assertions: `should.be_some` and `should.be_none`
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,21 +1,13 @@
 name = "gleeunit"
-version = "1.1.2"
+version = "1.1.3"
 licences = ["Apache-2.0"]
 description = "Gleam bindings to Erlang's EUnit test framework"
 gleam = ">= 0.33.0"
 repository = { type = "github", user = "lpil", repo = "gleeunit" }
-links = [
-  { title = "Sponsor", href = "https://github.com/sponsors/lpil" },
-]
+links = [{ title = "Sponsor", href = "https://github.com/sponsors/lpil" }]
 
 [javascript.deno]
-allow_read = [
-  "gleam.toml",
-  "test",
-  "build",
-]
+allow_read = ["gleam.toml", "test", "build"]
 
 [dependencies]
-gleam_stdlib = "~> 0.32"
-
-[dev-dependencies]
+gleam_stdlib = ">= 0.32"

--- a/gleam.toml
+++ b/gleam.toml
@@ -2,12 +2,13 @@ name = "gleeunit"
 version = "1.1.3"
 licences = ["Apache-2.0"]
 description = "Gleam bindings to Erlang's EUnit test framework"
-gleam = ">= 0.33.0"
 repository = { type = "github", user = "lpil", repo = "gleeunit" }
 links = [{ title = "Sponsor", href = "https://github.com/sponsors/lpil" }]
+
+gleam = ">= 0.33.0"
 
 [javascript.deno]
 allow_read = ["gleam.toml", "test", "build"]
 
 [dependencies]
-gleam_stdlib = ">= 0.32"
+gleam_stdlib = ">= 0.33.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,8 +2,8 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.34.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1FB8454D2991E9B4C0C804544D8A9AD0F6184725E20D63C3155F0AEB4230B016" },
+  { name = "gleam_stdlib", version = "0.38.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "663CF11861179AF415A625307447775C09404E752FF99A24E2057C835319F1BE" },
 ]
 
 [requirements]
-gleam_stdlib = { version = "~> 0.32" }
+gleam_stdlib = { version = ">= 0.33.0 and < 2.0.0" }

--- a/src/gleeunit.gleam
+++ b/src/gleeunit.gleam
@@ -15,13 +15,13 @@ pub fn main() -> Nil {
 fn do_main() -> Nil
 
 @target(erlang)
+import gleam/dynamic.{type Dynamic}
+@target(erlang)
 import gleam/list
 @target(erlang)
 import gleam/result
 @target(erlang)
 import gleam/string
-@target(erlang)
-import gleam/dynamic.{type Dynamic}
 
 @target(erlang)
 fn do_main() -> Nil {

--- a/src/gleeunit/should.gleam
+++ b/src/gleeunit/should.gleam
@@ -4,8 +4,8 @@
 //// More information on running eunit can be found in [the rebar3
 //// documentation](https://rebar3.org/docs/testing/eunit/).
 
-import gleam/string
 import gleam/option.{type Option, None, Some}
+import gleam/string
 
 @external(erlang, "gleeunit_ffi", "should_equal")
 pub fn equal(a: t, b: t) -> Nil {


### PR DESCRIPTION
1. I do not know WHY the source links to github lead to gleam-lang/lpil still, but republishing should solve it. See https://hexdocs.pm/gleeunit/gleeunit.html
2. the 1.1.2 tag misses among other tags on github. It would be lovely if you could push your local tags, I can diff based upon them and fixup the changelog if you want me to take that chore off you.

TODOs, _IF_ you like the PR:

1. create 1.1.3 tag
2. release on github
3. publish on hex
