### PR TITLE
Fixes "0 tests" result not showing in yellow.

### DIFF
--- a/src/gleeunit_progress.erl
+++ b/src/gleeunit_progress.erl
@@ -420,7 +420,7 @@ print_results(Data, State) ->
     sync_end(Result).
 
 print_results(Color, 0, _, _, _, State) ->
-    print_colored(Color, "0 tests\n", State);
+    print_colored("0 tests\n", Color, State);
 print_results(Color, Total, Fail, Skip, Cancel, State) ->
     SkipText = format_optional_result(Skip, "skipped"),
     CancelText = format_optional_result(Cancel, "cancelled"),


### PR DESCRIPTION
While writing our own test suite, we found that there is a bug in the `progress_ffi.erl` code that will print the result in the "normal" color instead of the wanted "yellow". This is because the first arguments to `print_colored()` are swapped.