### PR TITLE
Fix error message for `let assert`

### DIFF
--- a/src/gleeunit_progress.erl
+++ b/src/gleeunit_progress.erl
@@ -281,7 +281,7 @@ inspect(X) ->
     gleam@string:inspect(X).
 
 print_gleam_failure_reason(
-    #{gleam_error := assert, message := Message, value := Value},
+    #{gleam_error := let_assert, message := Message, value := Value},
     State
 ) ->
     print_colored(indent(5, "~s~n", [Message]), ?RED, State),


### PR DESCRIPTION
I noticed that there was a line in the source code of the formatter which checked for `gleam_error: assert`, where I believe the intention is `gleam_error: let_assert`. This PR fixes that, improving the error message when a test crashes due to a failed `let assert`.
Before:
```
1) playground_test.failing_test
     #{function => <<"failing_test">>,line => 24,
       message => <<"Pattern match failed, no pattern matched the value.">>,
       module => <<"playground_test">>,value => false,
       gleam_error => let_assert}
     location: playground_test.failing_test:24
     stacktrace:
       playground_test.failing_test
     output:
```
After:
```
1) playground_test.failing_test
     Pattern match failed, no pattern matched the value.
        value: False
     location: playground_test.failing_test:26
     stacktrace:
       playground_test.failing_test
     output:
```