### PR TITLE
Nitpick: Clarify that number reported is number of passed tests, not total tests

### DIFF
--- a/src/gleeunit/internal/reporting.gleam
+++ b/src/gleeunit/internal/reporting.gleam
@@ -23,7 +23,8 @@ pub fn finished(state: State) -> Int {
       1
     }
     State(failed: 0, skipped: 0, ..) -> {
-      let message = "\n" <> int.to_string(state.passed) <> " tests, no failures"
+      let message =
+        "\n" <> int.to_string(state.passed) <> " passed, no failures"
       io.println(green(message))
       0
     }
@@ -31,7 +32,7 @@ pub fn finished(state: State) -> Int {
       let message =
         "\n"
         <> int.to_string(state.passed)
-        <> " tests, "
+        <> " passed, "
         <> int.to_string(state.failed)
         <> " failures"
       io.println(red(message))
@@ -41,7 +42,7 @@ pub fn finished(state: State) -> Int {
       let message =
         "\n"
         <> int.to_string(state.passed)
-        <> " tests, 0 failures, "
+        <> " passed, 0 failures, "
         <> int.to_string(state.skipped)
         <> " skipped"
       io.println(yellow(message))
@@ -51,7 +52,7 @@ pub fn finished(state: State) -> Int {
       let message =
         "\n"
         <> int.to_string(state.passed)
-        <> " tests, "
+        <> " passed, "
         <> int.to_string(state.failed)
         <> " failures, "
         <> int.to_string(state.skipped)


### PR DESCRIPTION
TL;DR: Changes "tests" to "passed" to explain that the number represents the number of passed tests, not overall tests.

I know this is an incredible nitpick, but I'm using the human-readable output of gleeunit to verify that my starter project still works correctly. For v1.4.0 (https://github.com/lpil/gleeunit/compare/v1.3.1...v1.4.0), the output changed from counting the **total number** of tests to counting the **number of passed** tests:

Example: 

https://github.com/rradczewski/kata-bootstraps/blob/main/gleam/test/bootstrap_test.gleam with gleeunit 1.3.1:

```
...
Failures:

  1) bootstrap_test.failing_test
     Values were not equal
     expected: True
          got: False
     output: 

Finished in 0.010 seconds
2 tests, 1 failures
```

With gleeunit 1.4.0 and later:

```
...
 info: 
False
should equal
True

1 tests, 1 failures
```

The old implementation was here: https://github.com/lpil/gleeunit/blob/dee7bf6fd89ce97d7545b130991df5713bd61183/src/gleeunit_progress.erl#L427

For reference, here's an overview of other testrunners and how their human-readable report looks like: https://github.com/search?q=repo%3Arradczewski%2Fkata-bootstraps+%22failingTestVerification%22&type=code