### PR TITLE
Fix file paths on windows by normalising paths

### DIFF
--- a/test/gleam_panics_test.gleam
+++ b/test/gleam_panics_test.gleam
@@ -1,10 +1,15 @@
 import gleam/dynamic
 import gleam/function
+import gleam/string
 import gleeunit/internal/gleam_panic.{
   Assert, BinaryOperator, Expression, FunctionCall, LetAssert, Literal,
   OtherExpression, Panic, Todo, Unevaluated,
 }
 import testhelper
+
+fn normalize_path(path: String) -> String {
+  string.replace(path, "\\", "/")
+}
 
 @external(erlang, "gleeunit_test_ffi", "rescue")
 @external(javascript, "./gleeunit_test_ffi.mjs", "rescue")
@@ -13,7 +18,7 @@ fn rescue(f: fn() -> t) -> Result(t, dynamic.Dynamic)
 pub fn panic_test() {
   let assert Error(e) = rescue(fn() { panic })
   let assert Ok(e) = gleam_panic.from_dynamic(e)
-  assert e.file == "test/gleam_panics_test.gleam"
+  assert normalize_path(e.file) == "test/gleam_panics_test.gleam"
   assert e.kind == Panic
   assert e.function == "panic_test"
   assert e.module == "gleam_panics_test"
@@ -24,7 +29,7 @@ pub fn panic_test() {
 pub fn panic_message_test() {
   let assert Error(e) = rescue(fn() { panic as "oh my!" })
   let assert Ok(e) = gleam_panic.from_dynamic(e)
-  assert e.file == "test/gleam_panics_test.gleam"
+  assert normalize_path(e.file) == "test/gleam_panics_test.gleam"
   assert e.kind == Panic
   assert e.function == "panic_message_test"
   assert e.module == "gleam_panics_test"
@@ -35,7 +40,7 @@ pub fn panic_message_test() {
 pub fn todo_test() {
   let assert Error(e) = rescue(fn() { testhelper.run_todo() })
   let assert Ok(e) = gleam_panic.from_dynamic(e)
-  assert e.file == "src/testhelper.gleam"
+  assert normalize_path(e.file) == "src/testhelper.gleam"
   assert e.kind == Todo
   assert e.function == "run_todo"
   assert e.module == "testhelper"
@@ -47,7 +52,7 @@ pub fn todo_test() {
 pub fn todo_message_test() {
   let assert Error(e) = rescue(fn() { testhelper.run_todo_message("oh my!") })
   let assert Ok(e) = gleam_panic.from_dynamic(e)
-  assert e.file == "src/testhelper.gleam"
+  assert normalize_path(e.file) == "src/testhelper.gleam"
   assert e.kind == Todo
   assert e.function == "run_todo_message"
   assert e.module == "testhelper"
@@ -80,7 +85,7 @@ pub fn let_assert_message_test() {
       let assert 0 = function.identity(321) as "oh dear"
     })
   let assert Ok(e) = gleam_panic.from_dynamic(e)
-  assert e.file == "test/gleam_panics_test.gleam"
+  assert normalize_path(e.file) == "test/gleam_panics_test.gleam"
   assert e.function == "let_assert_message_test"
   assert e.module == "gleam_panics_test"
   assert e.line > 1
@@ -101,7 +106,7 @@ pub fn assert_expression_test() {
       assert x
     })
   let assert Ok(e) = gleam_panic.from_dynamic(e)
-  assert e.file == "test/gleam_panics_test.gleam"
+  assert normalize_path(e.file) == "test/gleam_panics_test.gleam"
   assert e.function == "assert_expression_test"
   assert e.module == "gleam_panics_test"
   assert e.line > 1
@@ -123,7 +128,7 @@ pub fn assert_expression_message_test() {
       assert x as "maybe?"
     })
   let assert Ok(e) = gleam_panic.from_dynamic(e)
-  assert e.file == "test/gleam_panics_test.gleam"
+  assert normalize_path(e.file) == "test/gleam_panics_test.gleam"
   assert e.function == "assert_expression_message_test"
   assert e.module == "gleam_panics_test"
   assert e.line > 1
@@ -144,7 +149,7 @@ pub fn assert_function_test() {
       assert function.identity(False)
     })
   let assert Ok(e) = gleam_panic.from_dynamic(e)
-  assert e.file == "test/gleam_panics_test.gleam"
+  assert normalize_path(e.file) == "test/gleam_panics_test.gleam"
   assert e.function == "assert_function_test"
   assert e.module == "gleam_panics_test"
   assert e.line > 1
@@ -165,7 +170,7 @@ pub fn assert_function_message_test() {
       assert function.identity(False) as "oh!"
     })
   let assert Ok(e) = gleam_panic.from_dynamic(e)
-  assert e.file == "test/gleam_panics_test.gleam"
+  assert normalize_path(e.file) == "test/gleam_panics_test.gleam"
   assert e.function == "assert_function_message_test"
   assert e.module == "gleam_panics_test"
   assert e.line > 1
@@ -187,7 +192,7 @@ pub fn assert_binary_operator_test() {
       assert a && function.identity(False)
     })
   let assert Ok(e) = gleam_panic.from_dynamic(e)
-  assert e.file == "test/gleam_panics_test.gleam"
+  assert normalize_path(e.file) == "test/gleam_panics_test.gleam"
   assert e.function == "assert_binary_operator_test"
   assert e.module == "gleam_panics_test"
   assert e.line > 1


### PR DESCRIPTION
#59 

Fixes  `gleam test` failures for this repo on windows, due to differences in path literals. This normalises paths to forward-slash before comparison.