### PR TITLE
Add main_parallel() for parallel test execution via EUnit inparallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,41 @@ allow_read = [
   "build",
 ]
 ```
+
+### Parallel test execution
+
+If your tests are independent and don't share mutable state, you can run them
+in parallel using EUnit's `inparallel` mode:
+
+```gleam
+// In test/yourapp_test.gleam
+import gleeunit
+
+pub fn main() {
+  gleeunit.main_parallel()
+}
+```
+
+To switch back to sequential execution, change `main_parallel()` to `main()`.
+
+On JavaScript targets, `main_parallel()` falls back to sequential execution
+since Node.js and Deno are single-threaded.
+
+#### When parallel tests are safe
+
+Tests can run in parallel when each test is fully isolated. For example:
+
+- Each test creates its own in-memory database (no shared connections)
+- No named processes are started (use unnamed processes or unique names)
+- No shared ETS tables with `named_table` (unnamed ETS is fine)
+- No writes to the file system
+
+#### When parallel tests are not safe
+
+Tests that share mutable state will produce flaky failures when parallelized:
+
+- A shared database connection or shared database state between tests
+- Named processes (e.g., `gen_server` registered with a fixed name)
+- Shared named ETS tables modified by multiple tests
+- Tests that read/write the same files
+- Tests that depend on execution order

--- a/src/gleeunit.gleam
+++ b/src/gleeunit.gleam
@@ -14,6 +14,15 @@ pub fn main() -> Nil {
   do_main()
 }
 
+/// Find and run all test functions in parallel using EUnit's inparallel.
+/// Tests must not share mutable state (named processes, shared ETS, files).
+///
+/// On JavaScript targets, this falls back to sequential execution.
+///
+pub fn main_parallel() -> Nil {
+  do_main_parallel()
+}
+
 @external(javascript, "./gleeunit_ffi.mjs", "main")
 fn do_main() -> Nil {
   let options = [
@@ -28,6 +37,28 @@ fn do_main() -> Nil {
     |> list.map(gleam_to_erlang_module_name)
     |> list.map(dangerously_convert_string_to_atom(_, Utf8))
     |> run_eunit(options)
+
+  let code = case result {
+    Ok(_) -> 0
+    Error(_) -> 1
+  }
+  halt(code)
+}
+
+@external(javascript, "./gleeunit_ffi.mjs", "main")
+fn do_main_parallel() -> Nil {
+  let options = [
+    Verbose,
+    NoTty,
+    Report(#(GleeunitProgress, [Colored(True)])),
+    ScaleTimeouts(10),
+  ]
+
+  let result =
+    find_files(matching: "**/*.{erl,gleam}", in: "test")
+    |> list.map(gleam_to_erlang_module_name)
+    |> list.map(dangerously_convert_string_to_atom(_, Utf8))
+    |> run_eunit_parallel(options)
 
   let code = case result {
     Ok(_) -> 0
@@ -84,3 +115,6 @@ type EunitOption {
 
 @external(erlang, "gleeunit_ffi", "run_eunit")
 fn run_eunit(a: List(Atom), b: List(EunitOption)) -> Result(Nil, a)
+
+@external(erlang, "gleeunit_ffi", "run_eunit_parallel")
+fn run_eunit_parallel(a: List(Atom), b: List(EunitOption)) -> Result(Nil, a)

--- a/src/gleeunit_ffi.erl
+++ b/src/gleeunit_ffi.erl
@@ -1,6 +1,6 @@
 -module(gleeunit_ffi).
 
--export([find_files/2, run_eunit/2]).
+-export([find_files/2, run_eunit/2, run_eunit_parallel/2]).
 
 find_files(Pattern, In) ->
   Results = filelib:wildcard(binary_to_list(Pattern), binary_to_list(In)),
@@ -18,4 +18,17 @@ run_eunit(Tests, Options) ->
                 {error, Term} -> {error, Term}
             end
     end.
-    
+
+run_eunit_parallel(Tests, Options) ->
+    case code:which(eunit) of
+        non_existing ->
+            gleeunit@internal@reporting:eunit_missing();
+
+        _ ->
+            case eunit:test({inparallel, Tests}, Options) of
+                ok -> {ok, nil};
+                error -> {error, nil};
+                {error, Term} -> {error, Term}
+            end
+    end.
+


### PR DESCRIPTION
Adds an opt-in parallel mode that wraps test modules in EUnit's {inparallel, Tests} tuple. Existing main() behavior is unchanged. On JavaScript targets, main_parallel() falls back to sequential execution.

In our project (Curling IO) with 800ish server tests, this reduced test time from ~4s to ~0.85s. We figure we'll have well over 5,000 tests at some point, so this will be have a significant impact. Each test clones its own in-memory SQLite database from a cached template, so there's no shared mutable state between tests. Might be possible to do something similar with PostgreSQL templates, but I'm not sure.