### PR TITLE
Use `string.inspect` on `Literal` dynamic value instead of a `"literal" string

### DIFF
--- a/src/gleeunit/internal/reporting.gleam
+++ b/src/gleeunit/internal/reporting.gleam
@@ -183,7 +183,7 @@ fn assert_value(name: String, value: gleam_panic.AssertedExpression) -> String {
 fn inspect_value(value: gleam_panic.AssertedExpression) -> String {
   case value.kind {
     gleam_panic.Unevaluated -> grey("unevaluated")
-    gleam_panic.Literal(..) -> grey("literal")
+    gleam_panic.Literal(value:) -> string.inspect(value)
     gleam_panic.Expression(value:) -> string.inspect(value)
   }
 }


### PR DESCRIPTION
In some cases, the `gleam test` command don't print the `right` result when the assertion fails:
```
 code: assert void_html_sample() == "<some_tag>"
 left: "<some_tag/>"
right: literal
 info: Assertion failed.
```
Is there a specific reason for this `literal` string?
If not, this change prints the dynamic value instead, which I feel make it easier to see the difference:
```
 code: assert void_html_sample() == "<some_tag>"
 left: "<some_tag/>"
right: "<some_tag>"
 info: Assertion failed.
```

It would be even nicer with diff coloring, like in Elixir, but that's a level of complexity I'm not ready to take on for now :slightly_smiling_face: 